### PR TITLE
feat: Add Multiply-add function to compute x*y+z

### DIFF
--- a/src/gcalc.gleam
+++ b/src/gcalc.gleam
@@ -151,3 +151,19 @@ fn cbrt_iter(x0: Float, x1: Float, n: Float) -> Float {
     }
   }
 }
+
+// Multiply-add Function ------------------------------------------------------
+
+/// Returns the result of x*y+z 
+/// without losing precision in any intermediate result
+/// 
+/// Example:
+/// ```
+/// let x = 10.0
+/// let y = 20.0
+/// let z = 30.0
+/// fma(x,y,z) // 230.0
+/// ```
+pub fn fma(x: Float, y: Float, z: Float) -> Float {
+  x *. y +. z
+}

--- a/test/fma_test.gleam
+++ b/test/fma_test.gleam
@@ -1,0 +1,14 @@
+import gcalc
+import gleeunit/should
+
+/// Test that 10*20+30 = 230
+pub fn fma_10_20_30_test() {
+  gcalc.fma(10.0, 20.0, 30.0)
+  |> should.equal(230.0)
+}
+
+/// Test that -10*20+30 = -170
+pub fn fma_neg10_20_30_test() {
+  gcalc.fma(-10.0, 20.0, 30.0)
+  |> should.equal(-170.0)
+}


### PR DESCRIPTION
## Info
This PR adds a similar function method of C++'s [fma](https://cplusplus.com/reference/cmath/fma/) cmath function.

What has been added is:
- `fma(x,y,z)`: computes and returns the result of `x * y + z` without losing precision of any intermediate results.

Example:
```rust
let x = 15.0
let y = 16.0
let z = 17.0
fma(x, y, z) // 257.0
```
- test cases for fma() have been added to the test folder in it's own file.

![image](https://github.com/korbexmachina/gcalc/assets/90986300/abd78f2d-9fcf-461a-9cd8-df32dbb766a3)